### PR TITLE
134 compute dispro does not accept factors as x and y inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@ when available (#119).
 * `desc_rch()`, `desc_dch()` and `desc_outcome()` now handle out of 
 memory arrow Table (#127).
 
+* `compute_dispro()` now handles factors as `x` or `y` arguments,
+if levels are strictly equal to 0 and 1 (#134).
+
 ## Minor
 
 * Error and warnings all turned into `cli` syntax. Gathered redundant checkers

--- a/tests/testthat/_snaps/compute_dispro.md
+++ b/tests/testthat/_snaps/compute_dispro.md
@@ -7,3 +7,17 @@
       i `.data` detected as `demo` table.
       i `.data` detected as `demo` table.
 
+# factors with levels other than 0 and 1 are rejected
+
+    Code
+      compute_dispro(demo, y = "a_colitis", x = "nivolumab_fac")
+    Condition
+      Error in `purrr::map()`:
+      i In index: 1.
+      Caused by error in `purrr::map()`:
+      i In index: 1.
+      Caused by error in `c_or_abcd_core()`:
+      ! `nivolumab_fac` must be a factor with levels 0 and 1.
+      x Levels found: 0, 1, and 2
+      > Supply character vector(s), or factor(s) with levels 0 and 1 to `x`.
+


### PR DESCRIPTION
Fixing `compute_dispro()`

Internally, it required to check the class and (if factor) levels of x and y inputs in the core of compute_dispro (which is named `c_or_abcd()` )
In this core function, x and y are broken down to each of their elements (args `one_x` and `one_y`, resp.).

Also added a checker, which is defined outside of compute_dispro (same .R file), and called twice.

Would be glad if you take a look and let me know if your issue is completely fixed with this PR.

And the end of the day, we lose the "factor" information of the input in the returned table. I don't think this is too much of a trouble, especially since you can mix those factors with character vectors.