### PR TITLE
feat: tidy-select support in desc_facvar() and desc_cont() (#168)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,8 @@ Imports:
     purrr,
     rlang,
     stringr,
-    tidyr
+    tidyr,
+    tidyselect,
+    utils
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,24 @@
 
 ## New features
 
+* `desc_facvar()` and `desc_cont()` now accept
+[tidy-select](https://tidyselect.r-lib.org/) syntax in their `vf` and `vc`
+arguments, in addition to a character vector of column names. You can now write
+e.g. `desc_cont(df, where(is.numeric))` or `desc_facvar(df, starts_with("g"))`.
+Passing a character vector keeps working unchanged. (#168)
+
 * *New* `add_death()`, `add_serious()`, and `add_fup()` functions add outcome
 columns to a dataset using the `out` and `followup` tables. These functions
 work transparently with both in-memory and out-of-memory (Arrow) tables,
 fixing the `match requires vector arguments` error that occurred when using
 these tables in Arrow format (#144).
+
+## Bug fixes
+
+* `desc_cont()` now always returns a plain `data.frame`, as documented.
+Previously the class of the result depended on the input backend (an in-memory
+Arrow `Table` produced a `tibble`), which made the output inconsistent with
+data.frame, data.table and on-disk Arrow `Dataset` inputs.
 
 # vigicaen 2.0.0
 

--- a/R/desc_cont.R
+++ b/R/desc_cont.R
@@ -19,7 +19,10 @@
 #' The analogous for categorical variables is [desc_facvar()].
 #'
 #' @param .data A data.frame, where `vc` are column names of continuous variables
-#' @param vc A character vector, list of column names. Should only contain continuous variables
+#' @param vc <[`tidy-select`][dplyr::dplyr_tidy_select]> Columns to summarise.
+#' Should only resolve to continuous variables. Accepts a character vector of
+#' column names (e.g. `c("age", "bmi")`), bare column names, or tidy-select
+#' helpers such as `where(is.numeric)` or `starts_with()`.
 #' @param format A character string. How would you like the output? See details.
 #' @param digits A numeric. How many digits? This argument calls internal formatting function
 #' @param export_raw_values A logical. Should the raw values be exported?
@@ -77,6 +80,10 @@ desc_cont <-
            digits = 1,
            export_raw_values = FALSE
            ){
+
+    # resolve tidy-select / character selection to column names
+
+    vc <- resolve_columns(.data, rlang::enquo(vc))
 
     # checkers ----
 
@@ -221,11 +228,15 @@ desc_cont <-
 
     # ---- apply cc_core ----
 
+    # `as.data.frame()` enforces the documented return type: arrow's `collect()`
+    # returns a tibble for in-memory `Table`s, which would otherwise make the
+    # output class depend on the input backend.
     purrr::map(
       vc,
       cc_core
     ) |>
-      purrr::list_rbind()
+      purrr::list_rbind() |>
+      as.data.frame()
   }
 
 # Helpers ------------

--- a/R/desc_facvar.R
+++ b/R/desc_facvar.R
@@ -19,7 +19,10 @@
 #' Equivalent for continuous data is [desc_cont()].
 #'
 #' @param .data A data.frame, where `vf` are column names of categorical variables
-#' @param vf A character vector
+#' @param vf <[`tidy-select`][dplyr::dplyr_tidy_select]> Columns to summarise.
+#' Accepts a character vector of column names (e.g. `c("sex", "country")`), bare
+#' column names, or tidy-select helpers such as `where(is.character)` or
+#' `starts_with()`.
 #' @param format A character string, formatting options.
 #' @param digits A numeric. Number of digits for the percentage (passed to interval formatting function).
 #' @param pad_width A numeric. Minimum character length of value output (passed to `stringr::str_pad()`).
@@ -79,6 +82,10 @@ desc_facvar <-
             pad_width = 12,
             ncat_max = 20,
             export_raw_values = FALSE){
+
+    # resolve tidy-select / character selection to column names
+
+    vf <- resolve_columns(.data, rlang::enquo(vf))
 
     # only columns present in the dataset
 

--- a/R/resolve_columns.R
+++ b/R/resolve_columns.R
@@ -1,0 +1,47 @@
+# Resolve a column selection to character names
+#
+# Internal helper backing tidy-select support in [desc_facvar()] and
+# [desc_cont()]. A plain character vector keeps the historical behaviour (it is
+# returned untouched, then validated downstream by [check_columns_in_data()], so
+# existing error classes are preserved). Any other expression (bare names,
+# `where()`, `starts_with()`, integer positions, ...) is resolved through
+# [tidyselect::eval_select()].
+#
+# The legacy-vs-tidyselect branch is decided by evaluating the captured
+# expression on its own: if it yields a character vector, it is treated as a
+# vector of column names (this also covers external vectors such as
+# `vars <- c("a", "b"); desc_facvar(df, vars)`); otherwise tidy-select rules
+# apply.
+#
+# @param .data A data.frame, data.table, or arrow object.
+# @param var_quo A quosure capturing the user's column selection.
+# @param call The execution environment used for error reporting.
+# @returns A character vector of column names.
+resolve_columns <- function(.data, var_quo, call = rlang::caller_env()) {
+
+  selection <-
+    tryCatch(
+      rlang::eval_tidy(var_quo),
+      error = function(cnd) NULL
+    )
+
+  # legacy path: a character vector is returned as-is, so downstream validation
+  # (and its `columns_not_in_data` / `columns_not_numeric_integer` classes)
+  # is left untouched.
+  if (is.character(selection)) {
+    return(selection)
+  }
+
+  # tidy-select path: build a zero-row, type-preserving prototype so predicate
+  # helpers such as `where(is.numeric)` evaluate on the correct column types.
+  proto <-
+    if (inherits(.data, c("Table", "Dataset", "arrow_dplyr_query"))) {
+      dplyr::collect(utils::head(.data, 0L))
+    } else {
+      utils::head(.data, 0L)
+    }
+
+  names(
+    tidyselect::eval_select(var_quo, data = proto, error_call = call)
+  )
+}

--- a/man/desc_cont.Rd
+++ b/man/desc_cont.Rd
@@ -15,7 +15,10 @@ desc_cont(
 \arguments{
 \item{.data}{A data.frame, where \code{vc} are column names of continuous variables}
 
-\item{vc}{A character vector, list of column names. Should only contain continuous variables}
+\item{vc}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Columns to summarise.
+Should only resolve to continuous variables. Accepts a character vector of
+column names (e.g. \code{c("age", "bmi")}), bare column names, or tidy-select
+helpers such as \code{where(is.numeric)} or \code{starts_with()}.}
 
 \item{format}{A character string. How would you like the output? See details.}
 

--- a/man/desc_facvar.Rd
+++ b/man/desc_facvar.Rd
@@ -17,7 +17,10 @@ desc_facvar(
 \arguments{
 \item{.data}{A data.frame, where \code{vf} are column names of categorical variables}
 
-\item{vf}{A character vector}
+\item{vf}{<\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}> Columns to summarise.
+Accepts a character vector of column names (e.g. \code{c("sex", "country")}), bare
+column names, or tidy-select helpers such as \code{where(is.character)} or
+\code{starts_with()}.}
 
 \item{format}{A character string, formatting options.}
 

--- a/tests/testthat/test-desc_cont.R
+++ b/tests/testthat/test-desc_cont.R
@@ -275,6 +275,158 @@ test_that(
   }
 )
 
+test_that("tidy-select selection works and matches character input", {
+  df <-
+    data.frame(
+      smoke_status = c("smoker", "non-smoker",
+                       "smoker", "smoker",
+                       "smoker", "smoker",
+                       "non-smoker"
+      ),
+      age = c(60, 50, 56, 49, 75, 69, 85),
+      bmi = c(18, 30, 25, 22, 23, 21, 22)
+    )
+
+  ref <- desc_cont(.data = df, vc = c("age", "bmi"))
+
+  # bare column names
+  expect_equal(
+    desc_cont(.data = df, vc = c(age, bmi)),
+    ref
+  )
+
+  # predicate helper picks the numeric columns only
+  expect_equal(
+    desc_cont(.data = df, vc = tidyselect::where(is.numeric)),
+    ref
+  )
+
+  # name-pattern helper
+  expect_equal(
+    desc_cont(.data = df, vc = tidyselect::starts_with("a"))$var,
+    "age"
+  )
+
+  # external character vector keeps using the legacy path
+  vars <- c("age", "bmi")
+  expect_equal(
+    desc_cont(.data = df, vc = vars),
+    ref
+  )
+
+  # tidy-select also works on arrow objects (type-preserving prototype)
+  df_arrow <- arrow::as_arrow_table(df)
+  expect_equal(
+    desc_cont(.data = df_arrow, vc = tidyselect::where(is.numeric))$var,
+    c("age", "bmi")
+  )
+})
+
+test_that("tidy-select results are identical to the character-vector form", {
+  df <-
+    data.frame(
+      grp = c("a", "a", "b", "b", "b", "a", "b"),
+      age = c(60, 50, 56, 49, 75, 69, 85),
+      bmi = c(18, 30, 25, 22, 23, 21, 22),
+      wt  = c(60, 80, 75, 62, 91, 70, 66)
+    )
+
+  expect_equal(
+    desc_cont(df, tidyselect::where(is.numeric)),
+    desc_cont(df, c("age", "bmi", "wt"))
+  )
+
+  expect_equal(
+    desc_cont(df, c(age, wt)),
+    desc_cont(df, c("age", "wt"))
+  )
+
+  expect_equal(
+    desc_cont(df, tidyselect::starts_with("b")),
+    desc_cont(df, "bmi")
+  )
+
+  expect_equal(
+    desc_cont(df, 2:3),
+    desc_cont(df, c("age", "bmi"))
+  )
+})
+
+test_that("tidy-select preserves legacy error classes", {
+  df <-
+    data.frame(age = c(60, 50), txt = c("a", "b"))
+
+  # absent character column -> historical 'not in data' error
+  expect_error(
+    desc_cont(df, c("absent")),
+    class = "columns_not_in_data"
+  )
+
+  # a character column selected by name -> 'not numeric/integer' error
+  expect_error(
+    desc_cont(df, c("txt")),
+    class = "columns_not_numeric_integer"
+  )
+
+  # a bare, non-existent name routes to tidy-select and errors there
+  expect_error(
+    desc_cont(df, absent),
+    regexp = "absent"
+  )
+})
+
+test_that("tidy-select works on arrow tables and datasets", {
+  df <-
+    data.frame(
+      grp = c("a", "b", "a", "b"),
+      age = c(60, 50, 56, 49),
+      bmi = c(18, 30, 25, 22)
+    )
+
+  # in-memory arrow Table: where() picks the numeric columns only, and the
+  # result is identical to the data.frame computation (same class and values)
+  at <- arrow::as_arrow_table(df)
+  expect_equal(
+    desc_cont(at, tidyselect::where(is.numeric)),
+    desc_cont(df, c("age", "bmi"))
+  )
+
+  # on-disk arrow Dataset
+  skip_on_cran()
+  tmp_folder <- file.path(tempdir(), "desc_cont_ds_tidyselect")
+  dir.create(tmp_folder)
+  on.exit(unlink(tmp_folder, recursive = TRUE), add = TRUE)
+  arrow::write_parquet(df, file.path(tmp_folder, "d.parquet"))
+  ds <- arrow::open_dataset(tmp_folder)
+
+  expect_equal(
+    desc_cont(ds, tidyselect::where(is.numeric))$var,
+    c("age", "bmi")
+  )
+})
+
+test_that("desc_cont returns a plain data.frame for every backend", {
+  df <- data.frame(grp = c("a", "b", "a"), age = c(60, 50, 56))
+
+  expect_identical(class(desc_cont(df, "age")), "data.frame")
+  expect_identical(
+    class(desc_cont(data.table::as.data.table(df), "age")),
+    "data.frame"
+  )
+  expect_identical(
+    class(desc_cont(arrow::as_arrow_table(df), "age")),
+    "data.frame"
+  )
+
+  skip_on_cran()
+  tmp_folder <- file.path(tempdir(), "desc_cont_type_ds")
+  dir.create(tmp_folder)
+  on.exit(unlink(tmp_folder, recursive = TRUE), add = TRUE)
+  arrow::write_parquet(df, file.path(tmp_folder, "d.parquet"))
+  ds <- arrow::open_dataset(tmp_folder)
+  expect_identical(class(desc_cont(ds, "age")), "data.frame")
+})
+
 test_that("exporting raw values works", {
   df <-
     data.frame(

--- a/tests/testthat/test-desc_facvar.R
+++ b/tests/testthat/test-desc_facvar.R
@@ -370,6 +370,126 @@ test_that(
 )
 
 test_that(
+  "tidy-select selection works and matches character input", {
+    df <-
+      data.frame(
+        smoke_status = c("smoker", "non-smoker",
+                         "smoker", "smoker",
+                         "smoker", "smoker",
+                         "non-smoker"
+        ),
+        hta = c(1, 1, 0, 1, 0, 0, 0)
+      )
+
+    ref <- desc_facvar(.data = df, vf = c("hta", "smoke_status"),
+                       pad_width = 0)
+
+    # bare column names
+    expect_equal(
+      desc_facvar(.data = df, vf = c(hta, smoke_status), pad_width = 0),
+      ref
+    )
+
+    # everything() selects all columns, in column order
+    expect_equal(
+      desc_facvar(.data = df, vf = tidyselect::everything(), pad_width = 0),
+      desc_facvar(.data = df, vf = c("smoke_status", "hta"), pad_width = 0)
+    )
+
+    # predicate helper
+    expect_equal(
+      desc_facvar(.data = df, vf = tidyselect::where(is.character),
+                  pad_width = 0)$var,
+      c("smoke_status", "smoke_status")
+    )
+
+    # name-pattern helper
+    expect_equal(
+      desc_facvar(.data = df, vf = tidyselect::starts_with("hta"),
+                  pad_width = 0)$var,
+      c("hta", "hta")
+    )
+
+    # external character vector keeps using the legacy path
+    vars <- c("hta", "smoke_status")
+    expect_equal(
+      desc_facvar(.data = df, vf = vars, pad_width = 0),
+      ref
+    )
+  }
+)
+
+test_that(
+  "tidy-select results are identical to the character-vector form", {
+    df <-
+      data.frame(
+        sex = c("m", "f", "m", "f", "m"),
+        grp = c("a", "a", "b", "b", "b"),
+        hta = c(1, 0, 1, 1, 0)
+      )
+
+    expect_equal(
+      desc_facvar(df, tidyselect::everything(), pad_width = 0),
+      desc_facvar(df, c("sex", "grp", "hta"), pad_width = 0)
+    )
+
+    expect_equal(
+      desc_facvar(df, tidyselect::where(is.character), pad_width = 0),
+      desc_facvar(df, c("sex", "grp"), pad_width = 0)
+    )
+
+    expect_equal(
+      desc_facvar(df, c(grp, hta), pad_width = 0),
+      desc_facvar(df, c("grp", "hta"), pad_width = 0)
+    )
+
+    # complement selection
+    expect_equal(
+      desc_facvar(df, !tidyselect::where(is.numeric), pad_width = 0),
+      desc_facvar(df, c("sex", "grp"), pad_width = 0)
+    )
+  }
+)
+
+test_that(
+  "tidy-select preserves legacy error classes and errors on bare typos", {
+    df <-
+      data.frame(sex = c("m", "f"), hta = c(1, 0))
+
+    # character vector with an absent column keeps the historical error class
+    expect_error(
+      desc_facvar(df, c("absent")),
+      class = "columns_not_in_data"
+    )
+
+    expect_error(
+      desc_facvar(df, c("sex", "absent")),
+      class = "columns_not_in_data"
+    )
+
+    # a bare, non-existent name routes to tidy-select and errors there
+    expect_error(
+      desc_facvar(df, absent),
+      regexp = "absent"
+    )
+  }
+)
+
+test_that(
+  "tidy-select honours export_raw_values", {
+    df <-
+      data.frame(sex = c("m", "f", "m"), hta = c(1, 0, 1))
+
+    expect_equal(
+      desc_facvar(df, tidyselect::everything(),
+                  pad_width = 0, export_raw_values = TRUE),
+      desc_facvar(df, c("sex", "hta"),
+                  pad_width = 0, export_raw_values = TRUE)
+    )
+  }
+)
+
+test_that(
   "exporting raw values work", {
     df <-
       data.frame(

--- a/tests/testthat/test-resolve_columns.R
+++ b/tests/testthat/test-resolve_columns.R
@@ -1,0 +1,242 @@
+# Unit tests for the internal resolve_columns() helper that backs tidy-select
+# support in desc_facvar() and desc_cont().
+
+# A fixture mixing character, double and integer columns, with names chosen so
+# that the various name-pattern helpers resolve unambiguously.
+rc_df <- function() {
+  data.frame(
+    sex    = c("m", "f", "m"),
+    region = c("eu", "us", "eu"),
+    age    = c(40, 50, 60),
+    bmi    = c(20, 25, 30),
+    n1     = c(1L, 2L, 3L),
+    n2     = c(4L, 5L, 6L),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("character input is returned untouched (legacy path)", {
+  df <- rc_df()
+
+  expect_identical(
+    resolve_columns(df, rlang::quo(c("age", "bmi"))),
+    c("age", "bmi")
+  )
+
+  # a single string
+  expect_identical(resolve_columns(df, rlang::quo("age")), "age")
+
+  # the helper itself does not validate: absent names are returned as-is so
+  # the downstream checkers keep ownership of the error.
+  expect_identical(resolve_columns(df, rlang::quo(c("nope"))), "nope")
+
+  # column order from the character vector is preserved
+  expect_identical(
+    resolve_columns(df, rlang::quo(c("bmi", "age"))),
+    c("bmi", "age")
+  )
+})
+
+test_that("external character vectors use the legacy path without warning", {
+  df <- rc_df()
+  vars <- c("region", "age")
+
+  expect_identical(
+    expect_no_warning(resolve_columns(df, rlang::quo(vars))),
+    c("region", "age")
+  )
+})
+
+test_that("bare column names are resolved via tidy-select", {
+  df <- rc_df()
+
+  expect_identical(resolve_columns(df, rlang::quo(c(age, bmi))), c("age", "bmi"))
+  # order is preserved
+  expect_identical(resolve_columns(df, rlang::quo(c(bmi, age))), c("bmi", "age"))
+  # a single bare name
+  expect_identical(resolve_columns(df, rlang::quo(age)), "age")
+})
+
+test_that("integer positions are resolved via tidy-select", {
+  df <- rc_df()
+
+  expect_identical(resolve_columns(df, rlang::quo(3:4)), c("age", "bmi"))
+  expect_identical(resolve_columns(df, rlang::quo(c(1, 3))), c("sex", "age"))
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::last_col())),
+    "n2"
+  )
+})
+
+test_that("predicate helper where() respects column types", {
+  df <- rc_df()
+
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::where(is.character))),
+    c("sex", "region")
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::where(is.double))),
+    c("age", "bmi")
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::where(is.integer))),
+    c("n1", "n2")
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::where(is.numeric))),
+    c("age", "bmi", "n1", "n2")
+  )
+})
+
+test_that("name-pattern helpers resolve correctly", {
+  df <- rc_df()
+
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::starts_with("n"))),
+    c("n1", "n2")
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::ends_with("e"))),
+    "age"
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::contains("gi"))),
+    "region"
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::matches("^n[12]$"))),
+    c("n1", "n2")
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::num_range("n", 1:2))),
+    c("n1", "n2")
+  )
+})
+
+test_that("everything(), complements and combinations work", {
+  df <- rc_df()
+
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::everything())),
+    names(df)
+  )
+  # complement of a predicate
+  expect_identical(
+    resolve_columns(df, rlang::quo(!tidyselect::where(is.character))),
+    c("age", "bmi", "n1", "n2")
+  )
+  # explicit de-selection
+  expect_identical(
+    resolve_columns(df, rlang::quo(c(-age, -bmi, -n1, -n2))),
+    c("sex", "region")
+  )
+  # mixing a bare name with a helper
+  expect_identical(
+    resolve_columns(df, rlang::quo(c(age, tidyselect::starts_with("n")))),
+    c("age", "n1", "n2")
+  )
+})
+
+test_that("all_of() / any_of() resolve to the requested names", {
+  df <- rc_df()
+  vars <- c("age", "sex")
+
+  expect_identical(
+    suppressWarnings(resolve_columns(df, rlang::quo(tidyselect::all_of(vars)))),
+    c("age", "sex")
+  )
+  # any_of() silently drops names that are absent
+  expect_identical(
+    suppressWarnings(
+      resolve_columns(df, rlang::quo(tidyselect::any_of(c("age", "absent"))))
+    ),
+    "age"
+  )
+})
+
+test_that("an empty selection yields character(0)", {
+  df <- rc_df()
+
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::starts_with("zzz"))),
+    character(0)
+  )
+})
+
+test_that("a bare, non-existent column raises an informative error", {
+  df <- rc_df()
+
+  expect_error(
+    resolve_columns(df, rlang::quo(does_not_exist)),
+    regexp = "does_not_exist"
+  )
+})
+
+test_that("works on data.table input", {
+  df <- data.table::as.data.table(rc_df())
+
+  expect_identical(resolve_columns(df, rlang::quo(c("age", "bmi"))), c("age", "bmi"))
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::where(is.double))),
+    c("age", "bmi")
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::starts_with("n"))),
+    c("n1", "n2")
+  )
+})
+
+test_that("works on an in-memory arrow Table", {
+  df <- arrow::as_arrow_table(rc_df())
+
+  # character (legacy) path
+  expect_identical(resolve_columns(df, rlang::quo(c("age", "bmi"))), c("age", "bmi"))
+  # predicate helper needs the type-preserving prototype
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::where(is.numeric))),
+    c("age", "bmi", "n1", "n2")
+  )
+  expect_identical(
+    resolve_columns(df, rlang::quo(tidyselect::starts_with("n"))),
+    c("n1", "n2")
+  )
+})
+
+test_that("works on an arrow_dplyr_query", {
+  query <-
+    arrow::as_arrow_table(rc_df()) |>
+    dplyr::mutate(extra = 1)
+
+  expect_identical(
+    resolve_columns(query, rlang::quo(tidyselect::where(is.character))),
+    c("sex", "region")
+  )
+  expect_identical(
+    resolve_columns(query, rlang::quo(tidyselect::ends_with("a"))),
+    "extra"
+  )
+})
+
+test_that("works on an on-disk arrow Dataset", {
+  skip_on_cran()
+
+  df <- rc_df()
+  tmp_folder <- file.path(tempdir(), "rc_dataset_test")
+  dir.create(tmp_folder)
+  on.exit(unlink(tmp_folder, recursive = TRUE), add = TRUE)
+
+  arrow::write_parquet(df, file.path(tmp_folder, "d.parquet"))
+  ds <- arrow::open_dataset(tmp_folder)
+
+  expect_s3_class(ds, "Dataset")
+
+  expect_identical(
+    resolve_columns(ds, rlang::quo(c("age", "bmi"))),
+    c("age", "bmi")
+  )
+  expect_identical(
+    resolve_columns(ds, rlang::quo(tidyselect::where(is.numeric))),
+    c("age", "bmi", "n1", "n2")
+  )
+})


### PR DESCRIPTION
## Summary

Implements #168: `desc_facvar()` and `desc_cont()` gain tidy-select
compatibility for their `vf` / `vc` arguments, with **no backward issues**.

A new internal helper `resolve_columns()` captures the selection as a quosure:

- a **character vector** is returned untouched → the legacy path is
  byte-for-byte unchanged, preserving the existing error classes
  (`columns_not_in_data`, `columns_not_numeric_integer`);
- anything else (bare names, `where()`, `starts_with()`, `all_of()`, integer
  positions, complements, ...) is resolved via `tidyselect::eval_select()`
  against a zero-row, type-preserving prototype (so `where(is.numeric)` works,
  including on Arrow tables).

This is intentionally more conservative than replacing the internal name
checker outright, as the issue suggested: downstream code that catches the
existing error classes keeps working.

```r
desc_cont(df, where(is.numeric))
desc_facvar(df, starts_with("g"))
desc_cont(df, c(age, bmi))           # bare names
desc_facvar(df, c("sex", "smoke"))   # character vector still works
```

## Bug fix bundled in

While testing the Arrow path I found `desc_cont()` violated its documented
`@returns A data.frame`: an **in-memory Arrow `Table`** produced a `tibble`, so
the result class depended on the input backend (data.frame / data.table /
on-disk `Dataset` all returned a plain `data.frame`). Fixed by enforcing
`as.data.frame()` on the output, and locked in with a test across all backends.

## Tests

- New `test-resolve_columns.R` — unit tests for every selection style and
  backend: data.frame, data.table, in-memory Arrow `Table`, `arrow_dplyr_query`,
  on-disk Arrow `Dataset`.
- Expanded `test-desc_facvar.R` / `test-desc_cont.R` — tidy-select ↔ character
  equivalence, legacy error-class preservation, complement selection,
  `export_raw_values`, Arrow, and return-type consistency.

**Full suite: 985 pass / 0 fail / 0 warn / 0 skip** (run with `NOT_CRAN=true`
and `vdiffr` installed, R 4.5.2).

## Test plan

- [x] `desc_facvar()` / `desc_cont()` unit + integration tests pass
- [x] Legacy character-vector calls unchanged (existing tests untouched)
- [x] Internal callers `desc_tto()` and `add_dose()` still green
- [x] Full `testthat` suite green
- [ ] CI (R CMD check across platforms)

## Notes

- Adds `tidyselect` and `utils` to `Imports`.
- `NAMESPACE` unchanged; man pages regenerated with roxygen2 8.0.0.

Closes #168
