### PR TITLE
docs: add FAQ and frequent errors article (#159)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^.vs$
 ^.vscode$
 ^CODE_OF_CONDUCT\.md$
+^vignettes/articles$

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@ work transparently with both in-memory and out-of-memory (Arrow) tables,
 fixing the `match requires vector arguments` error that occurred when using
 these tables in Arrow format (#144).
 
+## Documentation
+
+* *New* "FAQ and frequent errors" article collecting common errors (e.g. the
+arrow `malloc ... failed` out-of-memory error, and drug/effect name mismatches
+in `vigi_routine()`) together with proposed solutions. (#159)
+
 # vigicaen 2.0.0
 
 ## Breaking changes

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,3 +24,9 @@ articles:
   - template_dictionary
   - template_main
   - template_routine
+
+- title: Help
+  navbar: Help
+  desc: Troubleshooting and frequently asked questions
+  contents:
+  - articles/faq

--- a/vignettes/articles/faq.Rmd
+++ b/vignettes/articles/faq.Rmd
@@ -1,0 +1,75 @@
+---
+title: "FAQ and frequent errors"
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This page collects errors and warnings you may run into while using vigicaen,
+together with a proposed solution for each.
+
+It is meant to grow over time. If you hit an error that is not listed here ---
+or if a proposed solution does not work for you --- please
+[open an issue](https://github.com/pharmacologie-caen/vigicaen/issues).
+
+## General errors
+
+### 🔴 `malloc of size XXX failed`
+
+❓ This error comes from the [arrow](https://arrow.apache.org/docs/r/)
+back-end. It means the computer does not have enough RAM (memory) to process
+the tables any further. It is more likely to happen when large tables are
+loaded **in memory**.
+
+vigicaen is optimized for low-specification computers (e.g. with 16 GB of RAM),
+but not all use-cases will work on every computer. In some cases, the error may
+also point to a sub-optimal process inside vigicaen itself, which is worth
+reporting.
+
+✅ **How to solve it?**
+
+- Load tables **out of memory**, e.g. with `dt_parquet("xx", in_memory = FALSE)`,
+  or `arrow::open_dataset("xx")`.
+- Free up RAM by closing other programs running on your computer.
+- Analyse a **subset** of VigiBase rather than the full dataset.
+- Use a more powerful computer.
+- Consider
+  [reporting an issue](https://github.com/pharmacologie-caen/vigicaen/issues),
+  especially if a routine analysis exhausts memory unexpectedly.
+
+## `vigi_routine()`
+
+### 🔴 The drug and effect names on the graphic do not match my request
+
+❓ `vigi_routine()` produced a graphic, but the names displayed at the top of
+the figure do not match the ones you asked for. This usually happens when the
+names used to build `d_drecno` or `a_llt` get out of sync with the names passed
+to `vigi_routine()`. Two common situations:
+
+1. You changed the drug and/or effect name when creating `d_drecno` or `a_llt`,
+   but did not re-run that code.
+2. You did change the name and re-ran the code, but only updated the *value* of
+   the list item, not its *name*:
+
+``` r
+# the list item is still named "old_drug"
+d_drecno <- get_drecno(list(old_drug = "new_drug"), mp)
+```
+
+Both the name and the value of the list item should be updated, e.g.
+`"old_drug"` -> `"new_drug"`:
+
+``` r
+d_drecno <- get_drecno(list(new_drug = "new_drug"), mp)
+```
+
+✅ **How to solve it?**
+
+- Re-run the code that builds `d_drecno` and/or `a_llt`.
+- Make sure the **name** of each list item matches what you expect (see above).
+- Alternatively, set the labels explicitly with the `d_label` and `a_label`
+  arguments of `vigi_routine()`.


### PR DESCRIPTION
## Summary

Implements #159: a dedicated **FAQ and frequent errors** page, as suggested by
Marion. It is a living document — a place to write down errors as they occur,
each with a proposed solution.

It ships as a **pkgdown article** (`vignettes/articles/faq.Rmd`), registered
under a new **Help** section in the navbar. `vignettes/articles` is added to
`.Rbuildignore`, so the page is pkgdown-only and does not become a CRAN
vignette — it can grow freely without affecting the build/check cycle.

## Initial content

The two errors already documented in the issue:

- **`malloc of size XXX failed`** — the arrow out-of-memory error, with
  solutions (load out of memory, free RAM, analyse a subset, etc.).
- **`vigi_routine()` drug/effect names don't match the request** — the
  list-naming pitfall, with how to fix it (re-run / fix the list item name /
  use `d_label` & `a_label`).

## Validation

- Article knits cleanly (`knitr::knit`).
- `pkgdown::as_pkgdown()` detects `articles/faq`; the articles index builds with
  no missing or unlisted articles.

## Test plan

- [x] `_pkgdown.yml` parses and lists the article
- [x] Article renders without error
- [ ] Visual check of the rendered pkgdown site / Help navbar entry

## Notes

- Future entries can be appended under the existing **General errors** /
  per-function sections.

Closes #159
