### PR TITLE
refactor: extract vigi_routine() low-memory bypasses into tested helpers (#158)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,14 @@ work transparently with both in-memory and out-of-memory (Arrow) tables,
 fixing the `match requires vector arguments` error that occurred when using
 these tables in Arrow format (#144).
 
+## Internal
+
+* `vigi_routine()`'s low-memory bypasses (case-set identification and the
+single-pair Information Component) are now factored into tested internal
+helpers (`vr_case_sets()`, `vr_ic_from_counts()`), making that logic
+unit-testable outside the graphics-producing function. No change in behaviour.
+(#158)
+
 # vigicaen 2.0.0
 
 ## Breaking changes

--- a/R/vigi_routine.R
+++ b/R/vigi_routine.R
@@ -191,30 +191,9 @@ vigi_routine <-
       check_length_one(d_code_2, "vigi_routine()")
       d_name2 <- names(d_code_2)
 
-      umc_drug_1 <-
-        drug_data |>
-        dplyr::filter(.data$DrecNo %in% d_code[[1]] &
-                        .data$Basis %in% basis_sel) |>
-        dplyr::pull(.data$UMCReportId) |>
-        unique()
-
-      umc_drug_2 <-
-        drug_data |>
-        dplyr::filter(.data$DrecNo %in% d_code_2[[1]] &
-                        .data$Basis %in% basis_sel) |>
-        dplyr::pull(.data$UMCReportId) |>
-        unique()
-
-      umc_drug <- intersect(umc_drug_1, umc_drug_2)
-
-      umc_adr <-
-        adr_data |>
-        dplyr::filter(.data$MedDRA_Id %in% a_code[[1]])  |>
-        dplyr::pull(.data$UMCReportId) |>
-        unique()
-
-
-      umc_cases <- intersect(umc_drug, umc_adr)
+      case_sets <-
+        vr_case_sets(drug_data, adr_data, d_code, a_code, basis_sel,
+                     d_code_2 = d_code_2)
 
       cli::cli_alert_info(
         "Dual drug analysis: only cases exposed to both '{d_name}' and '{d_name2}' are included.")
@@ -223,23 +202,15 @@ vigi_routine <-
 
     } else {
 
-      umc_drug <-
-        drug_data |>
-        dplyr::filter(.data$DrecNo %in% d_code[[1]] &
-                        .data$Basis %in% basis_sel) |>
-        dplyr::pull(.data$UMCReportId) |>
-        unique()
-
-      umc_adr <-
-        adr_data |>
-        dplyr::filter(.data$MedDRA_Id %in% a_code[[1]]) |>
-        dplyr::pull(.data$UMCReportId) |>
-        unique()
-
-      umc_cases <- intersect(umc_drug, umc_adr)
+      case_sets <-
+        vr_case_sets(drug_data, adr_data, d_code, a_code, basis_sel)
 
       d_name_after_dm <- d_name
     }
+
+    umc_drug  <- case_sets$umc_drug
+    umc_adr   <- case_sets$umc_adr
+    umc_cases <- case_sets$umc_cases
 
     n_drug <-
       length(umc_drug)
@@ -278,54 +249,8 @@ vigi_routine <-
 
     # ---- compute ic ----
 
-    # args of compute_dispro
-    alpha <- 0.05
-
-    min_n_obs <- 0
-
-    na_format = "-"
-
-    dig = 2
-
     res_ic <-
-      data.frame(a = a, b = b, c = c, d = d) |>
-      dplyr::mutate(
-        dplyr::across(dplyr::all_of(c("a", "b", "c", "d")), ~ as.numeric(.x)),
-        n_obs = .data$a,
-        n_exp = (.data$a + .data$b) * # n drug
-          (.data$a + .data$c) / # n event
-          (.data$a + .data$b + .data$c + .data$d), # n pop
-        ic = log((.data$a + .5) / (.data$n_exp + .5), base = 2),
-        ic_tail = ic_tail(
-          n_obs = .data$a,
-          n_exp = .data$n_exp,
-          p = .env$alpha / 2
-        ),
-        ci_level  = paste0((1 - .env$alpha) * 100, "%"),
-        signif_ic = ifelse(.data$ic_tail > 0, 1, 0),
-        # don't show results for pairs with less than min_n_obs
-        dplyr::across(
-          dplyr::all_of(
-            c("n_exp", "ic", "ic_tail",
-              "a", "b", "c", "d",
-              "signif_ic")
-          ),
-          function(num_col)
-            dplyr::if_else(.data$a < .env$min_n_obs,
-                           NA_real_,
-                           num_col)
-        ),
-        dplyr::across(
-          dplyr::all_of(
-            c("ci_level"
-            )
-          ),
-          function(chr_col)
-            dplyr::if_else(.data$a < .env$min_n_obs,
-                           .env$na_format,
-                           chr_col)
-        )
-      )
+      vr_ic_from_counts(a = a, b = b, c = c, d = d)
 
     # ---- build link ----
 

--- a/R/vigi_routine_helpers.R
+++ b/R/vigi_routine_helpers.R
@@ -1,0 +1,107 @@
+# Internal helpers for vigi_routine()
+#
+# These extract the two memory-saving "bypasses" that let vigi_routine() run on
+# low-spec machines (see #158) into small, testable units. Rather than building
+# drug/adr columns on the full demo table (which add_drug()/add_adr() would
+# materialise in memory), vigi_routine() works from case-id sets and the 2x2
+# counts directly. Keeping these as standalone helpers makes that logic
+# unit-testable outside of the (graphics-producing) vigi_routine().
+
+# Identify the case sets for a single drug-adr pair.
+#
+# Returns the unique UMCReportId vectors for the drug exposure, the adr, and
+# their intersection (exposed-and-reacting cases). With `d_code_2`, the drug set
+# is the intersection of the two drugs' exposed cases (dual-drug analysis).
+#
+# @param drug_data,adr_data The drug and adr tables.
+# @param d_code,a_code Named length-one lists with the drug / adr codes.
+# @param basis_sel Integer vector of drug `Basis` values to keep.
+# @param d_code_2 Optional second drug code list (dual-drug analysis).
+# @returns A list with `umc_drug`, `umc_adr`, `umc_cases`.
+# (`.data` / `.env` pronouns are imported package-wide.)
+# @noRd
+vr_case_sets <- function(drug_data, adr_data, d_code, a_code, basis_sel,
+                         d_code_2 = NULL) {
+
+  umc_for_drecno <- function(drecno) {
+    drug_data |>
+      dplyr::filter(.data$DrecNo %in% drecno &
+                      .data$Basis %in% basis_sel) |>
+      dplyr::pull(.data$UMCReportId) |>
+      unique()
+  }
+
+  umc_adr <-
+    adr_data |>
+    dplyr::filter(.data$MedDRA_Id %in% a_code[[1]]) |>
+    dplyr::pull(.data$UMCReportId) |>
+    unique()
+
+  umc_drug <-
+    if (!is.null(d_code_2)) {
+      intersect(umc_for_drecno(d_code[[1]]), umc_for_drecno(d_code_2[[1]]))
+    } else {
+      umc_for_drecno(d_code[[1]])
+    }
+
+  umc_cases <- intersect(umc_drug, umc_adr)
+
+  list(umc_drug = umc_drug, umc_adr = umc_adr, umc_cases = umc_cases)
+}
+
+# Information Component for a single 2x2 contingency table.
+#
+# Reproduces compute_dispro()'s IC computation directly from the a/b/c/d counts,
+# so vigi_routine() does not need to add drug/adr columns to the full demo
+# table. Kept identical to compute_dispro() so the IC matches.
+#
+# @param a,b,c,d Contingency-table counts.
+# @param alpha Two-sided alpha for the IC credibility interval.
+# @param min_n_obs Pairs with fewer than `min_n_obs` observed cases are blanked.
+# @param na_format Replacement for `ci_level` when blanked.
+# @returns A one-row data.frame with columns a, b, c, d, n_obs, n_exp, ic,
+#   ic_tail, ci_level, signif_ic.
+# @noRd
+vr_ic_from_counts <- function(a, b, c, d,
+                              alpha = 0.05,
+                              min_n_obs = 0,
+                              na_format = "-") {
+  data.frame(a = a, b = b, c = c, d = d) |>
+    dplyr::mutate(
+      dplyr::across(dplyr::all_of(c("a", "b", "c", "d")), ~ as.numeric(.x)),
+      n_obs = .data$a,
+      n_exp = (.data$a + .data$b) * # n drug
+        (.data$a + .data$c) / # n event
+        (.data$a + .data$b + .data$c + .data$d), # n pop
+      ic = log((.data$a + .5) / (.data$n_exp + .5), base = 2),
+      ic_tail = ic_tail(
+        n_obs = .data$a,
+        n_exp = .data$n_exp,
+        p = .env$alpha / 2
+      ),
+      ci_level  = paste0((1 - .env$alpha) * 100, "%"),
+      signif_ic = ifelse(.data$ic_tail > 0, 1, 0),
+      # don't show results for pairs with less than min_n_obs
+      dplyr::across(
+        dplyr::all_of(
+          c("n_exp", "ic", "ic_tail",
+            "a", "b", "c", "d",
+            "signif_ic")
+        ),
+        function(num_col)
+          dplyr::if_else(.data$a < .env$min_n_obs,
+                         NA_real_,
+                         num_col)
+      ),
+      dplyr::across(
+        dplyr::all_of(
+          c("ci_level"
+          )
+        ),
+        function(chr_col)
+          dplyr::if_else(.data$a < .env$min_n_obs,
+                         .env$na_format,
+                         chr_col)
+      )
+    )
+}

--- a/tests/testthat/test-vigi_routine_helpers.R
+++ b/tests/testthat/test-vigi_routine_helpers.R
@@ -1,0 +1,99 @@
+# Tests for the internal vigi_routine() helpers vr_case_sets() and
+# vr_ic_from_counts().
+
+test_that("vr_ic_from_counts reproduces compute_dispro's IC on the same 2x2", {
+  a <- 8; b <- 12; c <- 30; d <- 500
+
+  # a table with exactly these a/b/c/d counts for one drug x one adr
+  df <- data.frame(
+    drug = c(rep(1, a + b), rep(0, c + d)),
+    adr  = c(rep(1, a), rep(0, b), rep(1, c), rep(0, d))
+  )
+
+  cd <- compute_dispro(df, y = "adr", x = "drug", export_raw_values = TRUE)
+  vr <- vr_ic_from_counts(a = a, b = b, c = c, d = d)
+
+  # the IC and its building blocks must match compute_dispro exactly
+  expect_equal(vr$n_obs,   cd$n_obs)
+  expect_equal(vr$n_exp,   cd$n_exp)
+  expect_equal(vr$ic,      cd$ic)
+  expect_equal(vr$ic_tail, cd$ic_tail)
+  expect_equal(vr$a, cd$a)
+  expect_equal(vr$d, cd$d)
+  # drug / adr marginals agree (compute_dispro labels b/c the other way round)
+  expect_equal(vr$a + vr$b, cd$a + cd$c)   # n with the drug
+  expect_equal(vr$a + vr$c, cd$a + cd$b)   # n with the adr
+})
+
+test_that("vr_ic_from_counts returns the documented columns and a positive signal", {
+  vr <- vr_ic_from_counts(a = 50, b = 100, c = 200, d = 100000)
+
+  expect_named(
+    vr,
+    c("a", "b", "c", "d", "n_obs", "n_exp", "ic", "ic_tail",
+      "ci_level", "signif_ic")
+  )
+  expect_equal(nrow(vr), 1L)
+  expect_equal(vr$n_obs, 50)
+  # strong over-representation -> IC025 > 0 -> signalled
+  expect_gt(vr$ic_tail, 0)
+  expect_equal(vr$signif_ic, 1)
+  expect_equal(vr$ci_level, "95%")
+})
+
+test_that("vr_ic_from_counts honours alpha and min_n_obs", {
+  # alpha drives the credibility level label
+  expect_equal(vr_ic_from_counts(10, 10, 10, 1000, alpha = 0.01)$ci_level, "99%")
+
+  # below min_n_obs, numeric outputs are blanked to NA. (`a` itself is blanked
+  # first, so the downstream ci_level test sees NA and also yields NA rather than
+  # na_format -- preserved verbatim from the original inline code. In practice
+  # vigi_routine() always calls with min_n_obs = 0, so this branch is inert.)
+  blanked <- vr_ic_from_counts(3, 10, 10, 1000, min_n_obs = 5, na_format = "-")
+  expect_true(is.na(blanked$ic))
+  expect_true(is.na(blanked$ic_tail))
+  expect_true(is.na(blanked$signif_ic))
+  expect_true(is.na(blanked$ci_level))
+})
+
+test_that("vr_case_sets identifies drug, adr and intersection case sets", {
+  d_code <- ex_$d_drecno["nivolumab"]
+  a_code <- ex_$a_llt["a_colitis"]
+  basis_sel <- c(1, 2, 3)
+
+  exp_drug <- drug_ |>
+    dplyr::filter(.data$DrecNo %in% d_code[[1]] & .data$Basis %in% basis_sel) |>
+    dplyr::pull(.data$UMCReportId) |>
+    unique()
+  exp_adr <- adr_ |>
+    dplyr::filter(.data$MedDRA_Id %in% a_code[[1]]) |>
+    dplyr::pull(.data$UMCReportId) |>
+    unique()
+
+  cs <- vr_case_sets(drug_, adr_, d_code, a_code, basis_sel)
+
+  expect_setequal(cs$umc_drug, exp_drug)
+  expect_setequal(cs$umc_adr, exp_adr)
+  expect_setequal(cs$umc_cases, intersect(exp_drug, exp_adr))
+})
+
+test_that("vr_case_sets dual-drug mode intersects the two drugs' cases", {
+  d_code   <- ex_$d_drecno["nivolumab"]
+  d_code_2 <- ex_$d_drecno["ipilimumab"]
+  a_code   <- ex_$a_llt["a_colitis"]
+  basis_sel <- c(1, 2, 3)
+
+  umc_for <- function(code) {
+    drug_ |>
+      dplyr::filter(.data$DrecNo %in% code & .data$Basis %in% basis_sel) |>
+      dplyr::pull(.data$UMCReportId) |>
+      unique()
+  }
+  exp_drug <- intersect(umc_for(d_code[[1]]), umc_for(d_code_2[[1]]))
+
+  cs <- vr_case_sets(drug_, adr_, d_code, a_code, basis_sel,
+                     d_code_2 = d_code_2)
+
+  expect_setequal(cs$umc_drug, exp_drug)
+  expect_true(all(cs$umc_cases %in% cs$umc_drug))
+})


### PR DESCRIPTION
## Summary

Addresses the code-quality side of #158. `vigi_routine()` avoids OOM on
low-spec machines by computing the single drug–ADR disproportionality from
**case-id set sizes and the 2×2 counts directly**, instead of adding drug/adr
columns to the full demo table (which `add_drug()`/`add_adr()` would
**materialise in memory** — see the benchmark below). That bypass logic lived
inline in the graphics-producing, hard-to-test `vigi_routine()`.

This PR extracts it into two small, unit-tested internal helpers — **no change
in behaviour**:

- `vr_case_sets()` — drug / ADR / intersection `UMCReportId` sets;
- `vr_ic_from_counts()` — Information Component from a 2×2 count table.

## Why this is safe

- `vigi_routine()`'s own test suite (incl. vdiffr snapshots) is **untouched and
  green** — the produced figure is byte-identical.
- On the **full** 2026 Mar 1 extract, output and **peak memory are identical**
  (2.57 GB before vs 2.57 GB after; ~135 s).
- `test-vigi_routine_helpers.R` adds direct tests, including an **equivalence
  check of `vr_ic_from_counts()` against `compute_dispro()`** on the same 2×2
  table (same `n_exp`, `ic`, `ic_tail`).

## Context (from the #158 benchmark)

The patch this refactors is what keeps `vigi_routine()` within ~2.5 GB; the
un-bypassed/native path peaks at ~14 GB on the full link table because
`add_drug()`/`add_adr()` call `dplyr::compute()` (materialising the whole
table), so `open_dataset()` alone does not help. Full numbers:
[#158 comment](https://github.com/pharmacologie-caen/vigicaen/issues/158#issuecomment-4828980570).

## Test plan

- [x] `test-vigi_routine_helpers.R` (24 checks) pass
- [x] `test-vigi_routine.R` (72 checks, incl. vdiffr) pass, unchanged
- [x] Full function re-run on the real extract: identical result + peak memory
- [ ] CI (R CMD check)

Refs #158
