### PR TITLE
fix: validate repbasis, restore arrow option on exit, unify is_arrow (#183)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,21 @@ work transparently with both in-memory and out-of-memory (Arrow) tables,
 fixing the `match requires vector arguments` error that occurred when using
 these tables in Arrow format (#144).
 
+## Bug fixes and internal
+
+* `repbasis` is now validated: an empty or malformed value (e.g. `""` or
+`"xyz"`) raises a clear error instead of silently producing an empty selection
+and filtering the drug table to zero rows. (#183)
+
+* `add_dose()`, `add_ind()` and `vigi_routine()` now restore the global
+`arrow.pull_as_vector` option via `on.exit()`, so an error mid-function no
+longer leaves the user's option altered. (#183)
+
+* Internal: arrow-object detection is unified behind a single `is_arrow()`
+helper (previously written inline in two inconsistent spellings, so chained
+`arrow_dplyr_query` inputs were handled differently across functions); the
+`repbasis` parsing is consolidated into `parse_repbasis()`. (#183)
+
 # vigicaen 2.0.0
 
 ## Breaking changes

--- a/R/add_adr.R
+++ b/R/add_adr.R
@@ -115,7 +115,7 @@ add_adr <-
 
     t_ids <-
       purrr::map(a_code, function(a_code_batch){
-        if(any(c("Table", "Dataset") %in% class(.data))){
+        if(is_arrow(.data)){
           ad_rn |>
             dplyr::filter(.data$MedDRA_Id %in% a_code_batch) |>
             dplyr::pull(.data$t_id, as_vector = FALSE)
@@ -164,7 +164,7 @@ add_adr <-
 
     # compute everything (this is strictly required only for arrow objects)
 
-    if(any(c("Table", "Dataset") %in% class(.data))){
+    if(is_arrow(.data)){
       final_data |>
         dplyr::compute()
     } else {

--- a/R/add_dose.R
+++ b/R/add_dose.R
@@ -92,10 +92,11 @@ add_dose <-
 
     # keep original user option, then set it
 
-    original_user_option <- options("arrow.pull_as_vector")
+    original_user_option <- getOption("arrow.pull_as_vector")
 
     options(arrow.pull_as_vector = TRUE) # ! different from other add_* functions
     # as purpose is different (only used for a summary table)
+    on.exit(options(arrow.pull_as_vector = original_user_option), add = TRUE)
 
     # 1. checkers
 
@@ -106,11 +107,7 @@ add_dose <-
     data_type <-
       query_data_type(.data, ".data")
 
-    basis_sel <- c(
-      if (grepl("s", repbasis)) { 1 },
-      if (grepl("c", repbasis)) { 2 },
-      if (grepl("i", repbasis)) { 3 }
-    )
+    basis_sel <- parse_repbasis(repbasis)
 
     d_d_names_full <-
       paste0(d_dose_names, "_dose_mg_per_day")
@@ -247,14 +244,10 @@ add_dose <-
 
     }
 
-    # 8. restore user option
-
-    options(arrow.pull_as_vector = original_user_option)
-
     # compute everything (this is strictly
     # required only for arrow objects)
 
-    if(any(c("Table", "Dataset", "arrow_dplyr_query") %in% class(.data))){
+    if(is_arrow(.data)){
       return(.data |>
         dplyr::compute()
       )

--- a/R/add_drug.R
+++ b/R/add_drug.R
@@ -107,12 +107,7 @@ add_drug <-
       query_data_type(.data, ".data")
 
     basis_sel <-
-      c(
-        if(grepl("s", repbasis)){ 1 },
-        # subsidiary_files / Repbasis_Lx
-        if(grepl("c", repbasis)){ 2 },
-        if(grepl("i", repbasis)){ 3 }
-      )
+      parse_repbasis(repbasis)
 
     dd_rb <-
       drug_data |>
@@ -148,7 +143,7 @@ add_drug <-
 
     t_ids <-
       purrr::map(d_code, function(d_code_batch){
-        if(any(c("Table", "Dataset") %in% class(.data))){
+        if(is_arrow(.data)){
           dd_rb |>
             dplyr::filter(.data$did_col %in% d_code_batch) |>
             dplyr::pull(.data$t_id, as_vector = FALSE)
@@ -197,7 +192,7 @@ add_drug <-
 
     # compute everything (this is strictly required only for arrow objects)
 
-    if(any(c("Table", "Dataset") %in% class(.data))){
+    if(is_arrow(.data)){
       final_data |>
         dplyr::compute()
     } else {

--- a/R/add_ind.R
+++ b/R/add_ind.R
@@ -60,11 +60,12 @@ add_ind <-
 
     # 0. arrow options
 
-    # keep original user option, then set it
+    # keep original user option, then set it (restored on exit, even on error)
 
-    original_user_option <- options("arrow.pull_as_vector")
+    original_user_option <- getOption("arrow.pull_as_vector")
 
     options(arrow.pull_as_vector = FALSE)
+    on.exit(options(arrow.pull_as_vector = original_user_option), add = TRUE)
 
     # 1. checkers
 
@@ -197,13 +198,9 @@ add_ind <-
       dest_data_withcols |>
       dplyr::rename(dplyr::all_of(back_renamer))
 
-    # 8. restore user option
-
-    options(arrow.pull_as_vector = original_user_option)
-
     # 9. compute everything (this is strictly required only for arrow objects)
 
-    if(any(c("Table", "Dataset") %in% class(.data))){
+    if(is_arrow(.data)){
       final_data |>
         dplyr::compute()
     } else {

--- a/R/add_outcomes.R
+++ b/R/add_outcomes.R
@@ -95,7 +95,7 @@ add_death <-
         )
       )
 
-    if (any(c("Table", "Dataset") %in% class(.data))) {
+    if (is_arrow(.data)) {
       result |> dplyr::compute()
     } else {
       result
@@ -145,7 +145,7 @@ add_serious <-
         )
       )
 
-    if (any(c("Table", "Dataset") %in% class(.data))) {
+    if (is_arrow(.data)) {
       result |> dplyr::compute()
     } else {
       result
@@ -190,7 +190,7 @@ add_fup <-
         )
       )
 
-    if (any(c("Table", "Dataset") %in% class(.data))) {
+    if (is_arrow(.data)) {
       result |> dplyr::compute()
     } else {
       result

--- a/R/desc_cont.R
+++ b/R/desc_cont.R
@@ -130,7 +130,7 @@ desc_cont <-
       vc_s <- rlang::ensym(one_var)
 
       check_all_na <-
-        if (any(c("Table", "Dataset", "arrow_dplyr_query") %in% class(.data))) {
+        if (is_arrow(.data)) {
 
           n_na <-
             .data |>
@@ -288,7 +288,7 @@ error_columns_numeric_integer <-
 check_columns_numeric_integer <-
   function(.data, cols, call = rlang::caller_env())  {
 
-    if (any(c("Table", "Dataset", "arrow_dplyr_query") %in% class(.data))) {
+    if (is_arrow(.data)) {
       # for arrow objects, extract type from schema
       col_classes <-
         arrow::schema(.data)$fields |>

--- a/R/get_atc_code.R
+++ b/R/get_atc_code.R
@@ -71,14 +71,14 @@ get_atc_code <-
       cli::cli_warn("names of atc_sel were tolower-ed and trimed")
     }
 
-    if(any(c("Table", "Dataset") %in% class(mp))){
+    if(is_arrow(mp)){
       # automatically collect mp if out of memory
       # since it's a small table
       mp <-
         dplyr::collect(mp)
     }
 
-    if(any(c("Table", "Dataset") %in% class(thg_data))){
+    if(is_arrow(thg_data)){
       # automatically collect thg_data if out of memory
       # since it's a small table
       thg_data <-

--- a/R/get_drecno.R
+++ b/R/get_drecno.R
@@ -134,7 +134,7 @@ get_drecno <- function(
 
   check_data_mp(mp)
 
-  if(any(c("Table", "Dataset") %in% class(mp))){
+  if(is_arrow(mp)){
     # automatically collect mp if out of memory
     # since it's a small table
     mp <-

--- a/R/get_llt_smq.R
+++ b/R/get_llt_smq.R
@@ -79,7 +79,7 @@ get_llt_smq <-
         c("1", "2")
       }
 
-    if(any(c("Table", "Dataset") %in% class(smq_list))){
+    if(is_arrow(smq_list)){
       # automatically collect smq_list and smq_content if out of memory
       # since they are small tables
       smq_list <-
@@ -87,7 +87,7 @@ get_llt_smq <-
     }
 
 
-    if(any(c("Table", "Dataset") %in% class(smq_content))){
+    if(is_arrow(smq_content)){
       smq_content <-
         dplyr::collect(smq_content)
     }

--- a/R/get_llt_soc.R
+++ b/R/get_llt_soc.R
@@ -63,7 +63,7 @@ get_llt_soc <-
 
     term_col  <- paste0(term_level, "_name")
 
-    if(any(c("Table", "Dataset") %in% class(meddra))){
+    if(is_arrow(meddra)){
       # automatically collect meddra if out of memory
       # since it's a small table
       meddra <-

--- a/R/is_arrow.R
+++ b/R/is_arrow.R
@@ -1,0 +1,14 @@
+# Is `x` an out-of-memory arrow object?
+#
+# Internal predicate unifying the arrow-class checks used across the package,
+# which were previously written inline in two inconsistent spellings (some sites
+# omitted `"arrow_dplyr_query"`). Returns TRUE for arrow `Table`, `Dataset`, and
+# `arrow_dplyr_query` objects (the latter being the result of chained dplyr verbs
+# on arrow data before `collect()`/`compute()`).
+#
+# @param x An object.
+# @returns A logical scalar.
+# @noRd
+is_arrow <- function(x) {
+  inherits(x, c("Table", "Dataset", "arrow_dplyr_query"))
+}

--- a/R/parse_repbasis.R
+++ b/R/parse_repbasis.R
@@ -1,0 +1,30 @@
+# Parse and validate a `repbasis` string into drug `Basis` codes.
+#
+# `repbasis` selects which report bases to keep for a drug: "s" suspect (1),
+# "c" concomitant (2), "i" interacting (3). Any combination is allowed (e.g.
+# "sci", "s", "sc"). Previously this 5-line `grepl()` block was duplicated in
+# `add_drug()`, `add_dose()` and `vigi_routine()` with no validation, so an
+# empty or invalid `repbasis` (e.g. "" or "xyz") silently produced an empty
+# `basis_sel` and filtered the drug table to zero rows.
+#
+# @param repbasis A length-1 character string combining "s"/"c"/"i".
+# @param call The calling environment, for error reporting.
+# @returns An integer vector of `Basis` codes (subset of `c(1, 2, 3)`).
+# @noRd
+parse_repbasis <- function(repbasis, call = rlang::caller_env()) {
+  if (!rlang::is_string(repbasis) || !grepl("^[sci]+$", repbasis)) {
+    cli::cli_abort(
+      c("{.arg repbasis} must be a single string combining {.val s}, {.val c} \\
+         and {.val i}.",
+        "x" = "You supplied {.val {repbasis}}."),
+      class = "invalid_repbasis",
+      call = call
+    )
+  }
+
+  c(
+    if (grepl("s", repbasis)) 1,
+    if (grepl("c", repbasis)) 2,
+    if (grepl("i", repbasis)) 3
+  )
+}

--- a/R/vigi_routine.R
+++ b/R/vigi_routine.R
@@ -135,11 +135,12 @@ vigi_routine <-
   ){
     # #### 0. arrow options #### ####
 
-    # keep original user option, then set it
+    # keep original user option, then set it (restored on exit, even on error)
 
-    original_user_option <- options("arrow.pull_as_vector")
+    original_user_option <- getOption("arrow.pull_as_vector")
 
     options(arrow.pull_as_vector = FALSE)
+    on.exit(options(arrow.pull_as_vector = original_user_option), add = TRUE)
 
     # #### 0. checkers #### ####
     check_id_list_numeric(d_code)
@@ -175,12 +176,7 @@ vigi_routine <-
       if (suspect_only) {"s"} else {"sci"}
 
     basis_sel <-
-      c(
-        if(grepl("s", repbasis_sel)){ 1 },
-        # subsidiary_files / Repbasis_Lx
-        if(grepl("c", repbasis_sel)){ 2 },
-        if(grepl("i", repbasis_sel)){ 3 }
-      )
+      parse_repbasis(repbasis_sel)
 
     use_two_drugs <-
       !rlang::is_missing(d_code_2)
@@ -883,11 +879,6 @@ vigi_routine <-
     if(nrow(ttos) <= 2){
       cli::cli_alert_info("Not enough data to plot time to onset")
     }
-
-    # #### 7. restore user option #### ####
-
-    options(arrow.pull_as_vector = original_user_option)
-
 
     # #### 8.Display #### ####
     invisible(g_assembled)

--- a/tests/testthat/test-is_arrow.R
+++ b/tests/testthat/test-is_arrow.R
@@ -1,0 +1,23 @@
+test_that("is_arrow() is TRUE only for arrow objects", {
+  df <- data.frame(x = 1:3, y = c("a", "b", "c"))
+
+  # not arrow
+  expect_false(is_arrow(df))
+  expect_false(is_arrow(data.table::as.data.table(df)))
+  expect_false(is_arrow(1:3))
+  expect_false(is_arrow(NULL))
+
+  # in-memory arrow Table
+  at <- arrow::as_arrow_table(df)
+  expect_true(is_arrow(at))
+
+  # arrow_dplyr_query (chained dplyr on arrow before collect/compute)
+  expect_true(is_arrow(at |> dplyr::mutate(z = 1)))
+
+  # on-disk arrow Dataset
+  tmp <- file.path(tempdir(), "is_arrow_ds")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  arrow::write_parquet(df, file.path(tmp, "d.parquet"))
+  expect_true(is_arrow(arrow::open_dataset(tmp)))
+})

--- a/tests/testthat/test-parse_repbasis.R
+++ b/tests/testthat/test-parse_repbasis.R
@@ -1,0 +1,33 @@
+test_that("parse_repbasis() maps valid strings to Basis codes", {
+  expect_equal(parse_repbasis("s"), 1)
+  expect_equal(parse_repbasis("c"), 2)
+  expect_equal(parse_repbasis("i"), 3)
+  expect_equal(parse_repbasis("sci"), c(1, 2, 3))
+  expect_equal(parse_repbasis("sc"), c(1, 2))
+  expect_equal(parse_repbasis("ci"), c(2, 3))
+  # order follows s/c/i, not the order of the input characters
+  expect_equal(parse_repbasis("is"), c(1, 3))
+})
+
+test_that("parse_repbasis() rejects invalid input with a clear error", {
+  expect_error(parse_repbasis(""), class = "invalid_repbasis")
+  expect_error(parse_repbasis("xyz"), class = "invalid_repbasis")
+  expect_error(parse_repbasis("scix"), class = "invalid_repbasis")
+  expect_error(parse_repbasis("S"), class = "invalid_repbasis")
+  expect_error(parse_repbasis(c("s", "c")), class = "invalid_repbasis")
+  expect_error(parse_repbasis(NA_character_), class = "invalid_repbasis")
+  expect_error(parse_repbasis(1), class = "invalid_repbasis")
+})
+
+test_that("parse_repbasis() matches the previous inline behaviour for valid input", {
+  inline <- function(repbasis) {
+    c(
+      if (grepl("s", repbasis)) 1,
+      if (grepl("c", repbasis)) 2,
+      if (grepl("i", repbasis)) 3
+    )
+  }
+  for (rb in c("s", "c", "i", "sc", "si", "ci", "sci")) {
+    expect_equal(parse_repbasis(rb), inline(rb))
+  }
+})


### PR DESCRIPTION
Closes #183. Three low-risk fixes that each surfaced in ≥2 perspectives of the
package assessment.

### 1. `repbasis` validation (+ de-duplication)
New internal `parse_repbasis()` validates `^[sci]+$` and replaces the identical
5-line `grepl()` block previously copy-pasted in `add_drug()`, `add_dose()` and
`vigi_routine()`. An empty/invalid `repbasis` (`""`, `"xyz"`) now raises a clear
error (class `invalid_repbasis`) instead of silently yielding an empty
`basis_sel` and filtering the drug table to **zero rows**.

### 2. `arrow.pull_as_vector` restored via `on.exit()`
`add_dose()`, `add_ind()` and `vigi_routine()` restored the global option only at
the *end* of the function, so an error mid-way left the user's option corrupted.
Now restored via `on.exit(..., add = TRUE)` set right after it's changed — the
pattern `add_outcomes()` already uses. Capture switched from `options("…")` (a
list) to `getOption("…")` (the value) for a correct restore.

### 3. `is_arrow()` predicate
One internal `is_arrow(x) <- inherits(x, c("Table","Dataset","arrow_dplyr_query"))`
replaces **17** inline `any(c("Table","Dataset") %in% class(x))` checks that were
written in two spellings — some omitted `"arrow_dplyr_query"`, so chained-arrow
inputs were handled inconsistently across functions. This unifies that behaviour.

### Verification
- Full `testthat` suite green (**942 pass / 0 fail / 0 warn / 0 skip**, `NOT_CRAN`,
  with `vdiffr`). `vigi_routine()` snapshot tests unchanged → behaviour preserved.
- New `test-is_arrow.R` and `test-parse_repbasis.R` (incl. a parity check of
  `parse_repbasis()` vs the old inline block).
- `NAMESPACE`/man unchanged (function bodies only).

### Note on overlap with in-flight PRs
This branches off `master` and touches `desc_cont.R` (also in #180) and
`vigi_routine.R` (also in #182). The edits are in different regions, so any merge
conflict should be trivial; merge order isn't important. The two `is_arrow`
sites in `desc_cont.R` are included here for completeness of the unification.
