### PR TITLE
refactor: share a single core across add_death/add_serious/add_fup (#191)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@ work transparently with both in-memory and out-of-memory (Arrow) tables,
 fixing the `match requires vector arguments` error that occurred when using
 these tables in Arrow format (#144).
 
+## Internal
+
+* `add_death()`, `add_serious()` and `add_fup()` (which were ~95% identical) now
+share a single internal core (`add_outcome_flag()`) and an `abort_if_ind()`
+helper; the exported functions are thin wrappers. No change in behaviour. (#191)
+
 # vigicaen 2.0.0
 
 ## Breaking changes

--- a/R/add_outcomes.R
+++ b/R/add_outcomes.R
@@ -60,46 +60,10 @@ add_death <-
            col_name = "death") {
 
     check_data_out(out_data, "out_data")
+    abort_if_ind(.data, "add_death()")
 
-    data_type <- query_data_type(.data, ".data")
-
-    if (data_type == "ind") {
-      cli::cli_abort(
-        c(
-          '{.arg .data} must be one of {.code {c("demo", "drug", "adr", "link")}}.',
-          "x" = "{.code ind} tables not supported in {.code add_death()}."
-        )
-      )
-    }
-
-    old_opt <- getOption("arrow.pull_as_vector")
-    options(arrow.pull_as_vector = TRUE)
-    on.exit(options(arrow.pull_as_vector = old_opt), add = TRUE)
-
-    all_out_ids <-
-      out_data |>
-      dplyr::pull("UMCReportId")
-
-    death_ids <-
-      out_data |>
-      dplyr::filter(.data$Seriousness == "1") |>
-      dplyr::pull("UMCReportId")
-
-    result <-
-      .data |>
-      dplyr::mutate(
-        "{col_name}" := ifelse(
-          UMCReportId %in% .env$all_out_ids,
-          as.integer(UMCReportId %in% .env$death_ids),
-          NA_integer_
-        )
-      )
-
-    if (any(c("Table", "Dataset") %in% class(.data))) {
-      result |> dplyr::compute()
-    } else {
-      result
-    }
+    add_outcome_flag(.data, out_data, col_name,
+                     positive = rlang::quo(.data$Seriousness == "1"))
   }
 
 #' @rdname add_outcomes
@@ -110,46 +74,10 @@ add_serious <-
            col_name = "serious") {
 
     check_data_out(out_data, "out_data")
+    abort_if_ind(.data, "add_serious()")
 
-    data_type <- query_data_type(.data, ".data")
-
-    if (data_type == "ind") {
-      cli::cli_abort(
-        c(
-          '{.arg .data} must be one of {.code {c("demo", "drug", "adr", "link")}}.',
-          "x" = "{.code ind} tables not supported in {.code add_serious()}."
-        )
-      )
-    }
-
-    old_opt <- getOption("arrow.pull_as_vector")
-    options(arrow.pull_as_vector = TRUE)
-    on.exit(options(arrow.pull_as_vector = old_opt), add = TRUE)
-
-    all_out_ids <-
-      out_data |>
-      dplyr::pull("UMCReportId")
-
-    serious_ids <-
-      out_data |>
-      dplyr::filter(.data$Serious == "Y") |>
-      dplyr::pull("UMCReportId")
-
-    result <-
-      .data |>
-      dplyr::mutate(
-        "{col_name}" := ifelse(
-          UMCReportId %in% .env$all_out_ids,
-          as.integer(UMCReportId %in% .env$serious_ids),
-          NA_integer_
-        )
-      )
-
-    if (any(c("Table", "Dataset") %in% class(.data))) {
-      result |> dplyr::compute()
-    } else {
-      result
-    }
+    add_outcome_flag(.data, out_data, col_name,
+                     positive = rlang::quo(.data$Serious == "Y"))
   }
 
 #' @rdname add_outcomes
@@ -160,35 +88,69 @@ add_fup <-
            col_name = "fup") {
 
     check_data_fup(fup_data, "fup_data")
+    abort_if_ind(.data, "add_fup()")
 
-    data_type <- query_data_type(.data, ".data")
+    add_outcome_flag(.data, fup_data, col_name, positive = NULL)
+  }
 
-    if (data_type == "ind") {
+# ---- internal helpers --------------------------------------------------------
+
+# Abort if `.data` is an `ind` table (the add_outcome_* functions don't support
+# it). `fn` is the calling-function label shown in the message.
+abort_if_ind <-
+  function(.data, fn, call = rlang::caller_env()) {
+    if (query_data_type(.data, ".data") == "ind") {
       cli::cli_abort(
         c(
           '{.arg .data} must be one of {.code {c("demo", "drug", "adr", "link")}}.',
-          "x" = "{.code ind} tables not supported in {.code add_fup()}."
-        )
+          "x" = "{.code ind} tables not supported in {.code {fn}}."
+        ),
+        call = call
       )
     }
+  }
+
+# Shared core for add_death() / add_serious() / add_fup().
+#
+# `positive` is a quosure giving the per-row positive condition (e.g.
+# `Seriousness == "1"`). When `NULL` (followup), any case present in
+# `source_data` is coded 1 and others 0. With a `positive` condition, cases
+# present in `source_data` are coded 0/1 and cases absent from it are coded NA.
+# Works on both in-memory and arrow `.data` (compute()d for arrow).
+add_outcome_flag <-
+  function(.data, source_data, col_name, positive = NULL) {
 
     old_opt <- getOption("arrow.pull_as_vector")
     options(arrow.pull_as_vector = TRUE)
     on.exit(options(arrow.pull_as_vector = old_opt), add = TRUE)
 
-    fup_ids <-
-      fup_data |>
+    present_ids <-
+      source_data |>
       dplyr::pull("UMCReportId")
 
     result <-
-      .data |>
-      dplyr::mutate(
-        "{col_name}" := ifelse(
-          UMCReportId %in% .env$fup_ids,
-          1L,
-          0L
-        )
-      )
+      if (is.null(positive)) {
+        # presence-only (followup): in source -> 1, else 0
+        .data |>
+          dplyr::mutate(
+            "{col_name}" := ifelse(UMCReportId %in% .env$present_ids, 1L, 0L)
+          )
+      } else {
+        positive_ids <-
+          source_data |>
+          dplyr::filter(!!positive) |>
+          dplyr::pull("UMCReportId")
+
+        # present in source -> 0/1 ; absent from source -> NA
+        .data |>
+          dplyr::mutate(
+            "{col_name}" := ifelse(
+              UMCReportId %in% .env$present_ids,
+              as.integer(UMCReportId %in% .env$positive_ids),
+              NA_integer_
+            )
+          )
+      }
 
     if (any(c("Table", "Dataset") %in% class(.data))) {
       result |> dplyr::compute()


### PR DESCRIPTION
Closes #191.

`add_death()`, `add_serious()` and `add_fup()` were ~95 % identical — same
`check_data_*`, `ind`-abort, `arrow.pull_as_vector` handling, `%in% -> ifelse`
mutate, and compute-if-arrow tail — differing only in the source table, the
validator, the positive condition (`Seriousness == "1"` / `Serious == "Y"` /
presence), and the absent code (`NA` vs `0`).

### Change
Extracted two internal helpers and made the three exported functions thin
wrappers:
- `add_outcome_flag(.data, source_data, col_name, positive)` — the shared data
  logic. **Keeps the exact `%in%` mechanism**, so the output values *and* return
  class are unchanged.
- `abort_if_ind(.data, fn)` — the shared `ind`-table guard (the calling-function
  label is passed through so the error message and call display are identical).

Net −92/+60 lines.

### Verification (behaviour-identical)
- All `add_outcomes` tests pass unchanged — incl. the **error snapshots**
  (`ind`-abort and wrong-`out_data`/`fup_data`), which matched byte-for-byte, and
  the arrow ↔ in-memory parity, `col_name`, and 3-way/2-way coding tests.
- Full suite green (**914 / 0 / 0 / 0**).

### Deliberately out of scope
The performance review (F3) noted these scan `out` 4× and build ~357 MB id
vectors; a single-pass **join** core would fix that but can change the return
class for in-memory inputs (data.table → tibble via `left_join`). I kept this PR
a pure DRY refactor and left the join optimisation as a separate, deliberate
change. The shared core also makes adding seriousness sub-criteria (assessment
A6) a one-wrapper change.

_Tier-3 item from the package improvement assessment._
