### PR TITLE
feat: add col_select argument to dt_parquet() (#193)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## New features
 
+* `dt_parquet()` gains an optional `col_select` argument (tidy-select) to load
+only a subset of columns, which can greatly reduce memory use on the large main
+tables. Defaults to `NULL` (all columns), so existing calls are unchanged.
+Works for both in-memory and out-of-memory (`in_memory = FALSE`) loads. (#193)
+
 * *New* `add_death()`, `add_serious()`, and `add_fup()` functions add outcome
 columns to a dataset using the `out` and `followup` tables. These functions
 work transparently with both in-memory and out-of-memory (Arrow) tables,

--- a/R/dt_parquet.R
+++ b/R/dt_parquet.R
@@ -17,6 +17,10 @@
 #' @param name Optional. A character string. The file name (if absent from `path_base`).
 #' @param ext Optional. A character string. The file extension.
 #' @param in_memory Logical, should data be loaded in memory?
+#' @param col_select Optional. A <[`tidy-select`][dplyr::dplyr_tidy_select]>
+#' selection of columns to read (e.g. `c("UMCReportId", "DrecNo")`). Defaults to
+#' `NULL`, meaning all columns. Loading only the columns you need can greatly
+#' reduce memory use on the large main tables.
 #' @returns A data.table if `in_memory` is set to `TRUE`,
 #' a parquet Table if `in_memory` is set to `FALSE`.
 #' @keywords import
@@ -53,7 +57,8 @@
 dt_parquet <- function(path_base,
                    name = NULL,
                    ext = ".parquet",
-                   in_memory = TRUE){
+                   in_memory = TRUE,
+                   col_select = NULL){
 
   ext <-
     if(!is.null(name) && !grepl(".parquet$", name, perl = TRUE)) {
@@ -73,10 +78,15 @@ dt_parquet <- function(path_base,
 
   if(in_memory == TRUE){
     path |>
-    arrow::read_parquet(as_data_frame = TRUE) |>
+    arrow::read_parquet(as_data_frame = TRUE, col_select = {{ col_select }}) |>
     data.table::as.data.table()
   } else {
-    path |>
-      arrow::open_dataset()
+    ds <- arrow::open_dataset(path)
+
+    if (!rlang::quo_is_null(rlang::enquo(col_select))) {
+      ds <- dplyr::select(ds, {{ col_select }})
+    }
+
+    ds
   }
 }

--- a/man/dt_parquet.Rd
+++ b/man/dt_parquet.Rd
@@ -4,7 +4,13 @@
 \alias{dt_parquet}
 \title{Read parquet and convert to data.table}
 \usage{
-dt_parquet(path_base, name = NULL, ext = ".parquet", in_memory = TRUE)
+dt_parquet(
+  path_base,
+  name = NULL,
+  ext = ".parquet",
+  in_memory = TRUE,
+  col_select = NULL
+)
 }
 \arguments{
 \item{path_base}{A character string, providing the path to read from.}
@@ -14,6 +20,11 @@ dt_parquet(path_base, name = NULL, ext = ".parquet", in_memory = TRUE)
 \item{ext}{Optional. A character string. The file extension.}
 
 \item{in_memory}{Logical, should data be loaded in memory?}
+
+\item{col_select}{Optional. A <\code{\link[dplyr:dplyr_tidy_select]{tidy-select}}>
+selection of columns to read (e.g. \code{c("UMCReportId", "DrecNo")}). Defaults to
+\code{NULL}, meaning all columns. Loading only the columns you need can greatly
+reduce memory use on the large main tables.}
 }
 \value{
 A data.table if \code{in_memory} is set to \code{TRUE},

--- a/tests/testthat/test-dt_parquet.R
+++ b/tests/testthat/test-dt_parquet.R
@@ -80,3 +80,39 @@ test_that("alternative path syntaxes work",{
 
   unlink(paste0(path_data, "demo_altsynt.parquet"), recursive = TRUE)
 })
+
+test_that("col_select loads only the requested columns (in memory)", {
+  tmp <- file.path(tempdir(), "dtp_colselect")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  df <- data.frame(UMCReportId = 1:3, DrecNo = 4:6, extra = 7:9)
+  arrow::write_parquet(df, file.path(tmp, "t.parquet"))
+
+  # character selection
+  sel <- dt_parquet(tmp, "t", col_select = c("UMCReportId", "DrecNo"))
+  expect_true(data.table::is.data.table(sel))
+  expect_equal(names(sel), c("UMCReportId", "DrecNo"))
+
+  # bare tidy-select
+  sel2 <- dt_parquet(tmp, "t", col_select = c(UMCReportId, extra))
+  expect_equal(names(sel2), c("UMCReportId", "extra"))
+})
+
+test_that("col_select works out of memory, default loads all columns", {
+  tmp <- file.path(tempdir(), "dtp_colselect_oom")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  df <- data.frame(UMCReportId = 1:3, DrecNo = 4:6, extra = 7:9)
+  arrow::write_parquet(df, file.path(tmp, "t.parquet"))
+
+  # out of memory, default: all columns
+  ds_all <- dt_parquet(tmp, "t", in_memory = FALSE)
+  expect_false(data.table::is.data.table(ds_all))
+  expect_setequal(names(ds_all), c("UMCReportId", "DrecNo", "extra"))
+
+  # out of memory, col_select restricts the columns
+  ds_sel <- dt_parquet(tmp, "t", in_memory = FALSE,
+                       col_select = c("UMCReportId", "DrecNo"))
+  expect_equal(names(ds_sel), c("UMCReportId", "DrecNo"))
+  expect_equal(nrow(dplyr::collect(ds_sel)), 3L)
+})


### PR DESCRIPTION
Closes #193.

`dt_parquet(in_memory = TRUE)` read **every column** via
`arrow::read_parquet(as_data_frame = TRUE)`, with no way to request a subset —
the main RAM driver when loading the big tables in memory.

### Change (additive)
New optional **`col_select`** argument (tidy-select; default `NULL` = all
columns), forwarded to:
- `arrow::read_parquet(col_select = {{ col_select }})` for the in-memory path,
- `dplyr::select()` for the out-of-memory (`open_dataset`) path.

```r
dt_parquet("demo", col_select = c("UMCReportId", "AgeGroup"))
```

Existing calls are unchanged (`col_select = NULL`).

### Verification
- New `col_select` tests: in-memory (character **and** bare tidy-select) and
  out-of-memory (default-all + restricted). All pass.
- `dt_parquet()` coverage **100 %**; full suite green (921 / 0).
- Conflict-free: no other open PR touches `dt_parquet.R`.

_Perf roadmap item (F8) from the package improvement assessment._
